### PR TITLE
fix: Fix incorrect percentage of color shown in pie chart

### DIFF
--- a/Color Identification using Machine Learning.ipynb
+++ b/Color Identification using Machine Learning.ipynb
@@ -269,6 +269,8 @@
     "    labels = clf.fit_predict(modified_image)\n",
     "    \n",
     "    counts = Counter(labels)\n",
+    "    # sort to ensure correct color percentage\n",
+    "    counts = dict(sorted(counts.items()))\n",
     "    \n",
     "    center_colors = clf.cluster_centers_\n",
     "    # We get ordered colors by iterating through the keys\n",


### PR DESCRIPTION
If not sorted, the color are not shown according to their percentage sometimes (when the dictionary output is like `({1: 197893, 0: 42107})`)  as shown
![colpercentage](https://user-images.githubusercontent.com/20869671/67853562-d57b2780-fb34-11e9-9da1-57814901a6bb.png)

After sorting, it works correctly.

```
Before sorting:
Counter({1: 197893, 0: 42107})
After sorting:
{0: 42107, 1: 197893}
center_colors:  [[ 80.26107298  76.75108652 105.3527917 ]
 [242.4183675  239.69031244 238.70730647]]
ordered_colors:  [array([ 80.26107298,  76.75108652, 105.3527917 ]), array([242.4183675 , 239.69031244, 238.70730647])]
hex_colors:  ['#504c69', '#f2efee']
```